### PR TITLE
Use HTTPS where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   var respecConfig = {
     shortName: "resource-hints",
     specStatus: "ED",
-    edDraftURI: "http://w3c.github.io/resource-hints/",
+    edDraftURI: "https://w3c.github.io/resource-hints/",
     editors: [{
       name: "Ilya Grigorik",
       url: "https://www.igvita.com/",


### PR DESCRIPTION
`https://w3c.github.io/*` is available over HTTPS, so let’s use it.
