### PR TITLE
Disable linking in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
       <h2>Fetching the resource hint link</h2>
       <p>The <a>resource hint link</a>'s may be specified in the document markup, MAY be provided via the HTTP `Link` header, and MAY be dynamically added to and removed from the document.</p>
 
-      <pre class="example nohighlight">
+      <pre class="example nohighlight nolinks">
   Link: &lt;https://widget.com&gt;; rel=dns-prefetch
   Link: &lt;https://example.com&gt;; rel=preconnect
   Link: &lt;https://example.com/next-page.html&gt;; rel=prerender;


### PR DESCRIPTION
See https://github.com/w3c/respec/issues/777

PR coming to ReSpec to address this. Have it fixed locally. 
