### PR TITLE
chore: use faster/lighter ReSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <title>Resource Hints</title>
   <meta charset='utf-8'>
-  <script src='//www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
     shortName: "resource-hints",

--- a/index.html
+++ b/index.html
@@ -4,13 +4,11 @@
 <head>
   <title>Resource Hints</title>
   <meta charset='utf-8'>
-  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='//www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
     shortName: "resource-hints",
     specStatus: "ED",
-    useExperimentalStyles: true,
-    edDraftURI: "https://w3c.github.io/resource-hints/",
     editors: [{
       name: "Ilya Grigorik",
       url: "https://www.igvita.com/",
@@ -21,21 +19,7 @@
     }, ],
     wg: "Web Performance Working Group",
     wgURI: "https://www.w3.org/webperf/",
-    license: 'w3c-software-doc',
-    wgPublicList: "public-web-perf",
-    otherLinks: [{
-      key: 'Repository',
-      data: [{
-        value: 'We are on Github.',
-        href: 'https://github.com/w3c/resource-hints/'
-      }, {
-        value: 'File a bug.',
-        href: 'https://github.com/w3c/resource-hints/issues'
-      }, {
-        value: 'Commit history.',
-        href: 'https://github.com/w3c/resource-hints/commits/gh-pages/index.html'
-      }]
-    }],
+    github: "w3c/resource-hints",
     wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/45211/status"
   };
   </script>


### PR DESCRIPTION
Removed redundant ReSpec config things.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-hints/pull/92.html" title="Last updated on Jan 2, 2020, 3:15 AM UTC (e9731e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-hints/92/7e76769...e9731e2.html" title="Last updated on Jan 2, 2020, 3:15 AM UTC (e9731e2)">Diff</a>