### PR TITLE
chore: use ReSpec's group option

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,8 @@
       companyURL: "https://google.com/",
       w3cid: "56102"
     }, ],
-    wg: "Web Performance Working Group",
-    wgURI: "https://www.w3.org/webperf/",
     github: "w3c/resource-hints",
-    wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/45211/status"
+    group: "webperf",
   };
   </script>
 </head>


### PR DESCRIPTION
`wg`, `wgURI`, `wgPatentURI` are deprecated in favor of `group`.
This also sets the `wgPatentPolicy` option automatically. So, the spec now uses the correct (same as Web Perf WG) patent policy (2017).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/resource-hints/pull/95.html" title="Last updated on Oct 5, 2020, 5:22 PM UTC (1ca450a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-hints/95/51b69e8...sidvishnoi:1ca450a.html" title="Last updated on Oct 5, 2020, 5:22 PM UTC (1ca450a)">Diff</a>